### PR TITLE
Add responsive portfolio site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Nishant Subedi Portfolio
+
+Live site: <https://nsubedi2051.github.io>
+
+## Customize
+
+- Replace **LinkedIn** URL in `index.html` and `README.md` with your profile.
+- Update the email address (`your@email.com`) in `index.html`, `script.js` and `README.md`.
+- Add a profile photo at `assets/profile.jpg` (160×160 recommended). If the file is missing a gradient placeholder is shown.
+
+## Run locally
+
+- Open `index.html` directly in a browser, **or**
+- Serve the folder:
+  ```bash
+  python -m http.server
+  ```
+  then visit `http://localhost:8000`.
+
+## Deploy
+
+This repository is set up for GitHub Pages. Push to the `main` branch to publish.
+
+```bash
+git add .
+git commit -m "Update portfolio"
+git push origin main
+```

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
             rel="noopener"
             >LinkedIn</a
           >
-          <button class="btn" id="copyEmail" type="button">Copy Email</button>
+          <button class="btn" id="Email" type="button">Email</button>
         </div>
       </section>
 
@@ -65,18 +65,18 @@
           </li>
           <li>
             <a
-              href="https://www.linkedin.com/in/your-handle"
+              href="https://www.linkedin.com/in/nishant-subedi-6b58605a/"
               target="_blank"
               rel="noopener"
               >LinkedIn</a
             >
           </li>
-          <li><a href="mailto:your@email.com">Email</a></li>
+          <li><a href="mailto:nishantsubedi2051@gmail.com">Email</a></li>
         </ul>
       </section>
 
       <footer class="fade-in">
-        © 2025 Nishant Subedi — Hosted on GitHub Pages.
+        © 2025 Nishant — Hosted on GitHub Pages.
       </footer>
       <div id="toast" role="status" aria-live="polite"></div>
     </main>

--- a/index.html
+++ b/index.html
@@ -52,29 +52,6 @@
         </p>
       </section>
 
-      <section class="contact fade-in">
-        <h2>Contact</h2>
-        <ul>
-          <li>
-            <a
-              href="https://github.com/nsubedi2051"
-              target="_blank"
-              rel="noopener"
-              >GitHub</a
-            >
-          </li>
-          <li>
-            <a
-              href="https://www.linkedin.com/in/nishant-subedi-6b58605a/"
-              target="_blank"
-              rel="noopener"
-              >LinkedIn</a
-            >
-          </li>
-          <li><a href="mailto:nishantsubedi2051@gmail.com">Email</a></li>
-        </ul>
-      </section>
-
       <footer class="fade-in">
         © 2025 Nishant — Hosted on GitHub Pages.
       </footer>

--- a/index.html
+++ b/index.html
@@ -1,33 +1,86 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Your Name | Portfolio</title>
-  <style>
-    :root { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
-    body { margin:0; background:#0f172a; color:#e2e8f0; }
-    .wrap { max-width:760px; margin:12vh auto; padding:0 24px; }
-    h1 { font-size:clamp(32px,6vw,56px); margin:0 0 8px; line-height:1.05; }
-    h2 { margin:6px 0 24px; font-weight:500; color:#94a3b8; }
-    .btns { display:flex; gap:12px; flex-wrap:wrap; margin-top:28px; }
-    .btn { padding:12px 18px; border-radius:14px; border:1px solid #334155; text-decoration:none; color:#e2e8f0; }
-    .btn:hover { background:#1e293b; }
-    footer { margin-top:56px; color:#94a3b8; font-size:14px; }
-  </style>
-</head>
-<body>
-  <main class="wrap">
-    <h1>Your Name</h1>
-    <h2>Digital transformation • Accessibility • UX</h2>
-    <p>I build simple, inclusive solutions. Currently learning Python & web dev.</p>
-    <div class="btns">
-      <a class="btn" href="https://github.com/your-username" target="_blank">GitHub</a>
-      <a class="btn" href="https://www.linkedin.com/in/your-handle" target="_blank">LinkedIn</a>
-      <a class="btn" href="mailto:you@example.com">Email</a>
-      <a class="btn" href="tel:+61XXXXXXXXX">Call</a>
-    </div>
-    <footer>© 2025 Your Name. Hosted on GitHub Pages.</footer>
-  </main>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Nishant Subedi | Portfolio</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="container">
+      <section class="hero fade-in">
+        <div class="profile">
+          <img src="assets/profile.jpg" alt="Nishant Subedi profile photo" />
+        </div>
+        <h1>Nishant Subedi</h1>
+        <p class="role">
+          Digital transformation &amp; accessibility • Aspiring software
+          developer
+        </p>
+        <div class="interests">
+          <span class="badge">Python</span>
+          <span class="badge">Web Development</span>
+          <span class="badge">Automation</span>
+          <span class="badge">Accessibility</span>
+          <span class="badge">UX</span>
+        </div>
+        <div class="actions">
+          <a
+            class="btn"
+            href="https://github.com/nsubedi2051"
+            target="_blank"
+            rel="noopener"
+            >GitHub</a
+          >
+          <a
+            class="btn"
+            href="https://www.linkedin.com/in/your-handle"
+            target="_blank"
+            rel="noopener"
+            >LinkedIn</a
+          >
+          <button class="btn" id="copyEmail" type="button">Copy Email</button>
+        </div>
+      </section>
+
+      <section class="about fade-in">
+        <h2>About Me</h2>
+        <p>
+          I’m learning Python and modern web development while working on
+          inclusive, simple digital solutions. I enjoy building small tools that
+          make customer experiences clearer and more accessible.
+        </p>
+      </section>
+
+      <section class="contact fade-in">
+        <h2>Contact</h2>
+        <ul>
+          <li>
+            <a
+              href="https://github.com/nsubedi2051"
+              target="_blank"
+              rel="noopener"
+              >GitHub</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.linkedin.com/in/your-handle"
+              target="_blank"
+              rel="noopener"
+              >LinkedIn</a
+            >
+          </li>
+          <li><a href="mailto:your@email.com">Email</a></li>
+        </ul>
+      </section>
+
+      <footer class="fade-in">
+        © 2025 Nishant Subedi — Hosted on GitHub Pages.
+      </footer>
+      <div id="toast" role="status" aria-live="polite"></div>
+    </main>
+
+    <script src="script.js"></script>
+  </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,24 @@
+document.addEventListener("DOMContentLoaded", () => {
+  document.body.classList.add("loaded");
+
+  const email = "your@email.com";
+  const copyBtn = document.getElementById("copyEmail");
+  const toast = document.getElementById("toast");
+
+  if (copyBtn) {
+    copyBtn.addEventListener("click", () => {
+      navigator.clipboard.writeText(email).then(() => {
+        toast.textContent = "Copied!";
+        toast.classList.add("show");
+        setTimeout(() => toast.classList.remove("show"), 2000);
+      });
+    });
+  }
+
+  const img = document.querySelector(".profile img");
+  if (img) {
+    img.addEventListener("error", () => {
+      img.style.display = "none";
+    });
+  }
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,168 @@
+:root {
+  --bg: #0f172a;
+  --fg: #e2e8f0;
+  --accent: #38bdf8;
+  --muted: #94a3b8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family:
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  line-height: 1.6;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+}
+
+.profile {
+  width: 160px;
+  height: 160px;
+  margin: 0 auto 1.5rem;
+  border-radius: 50%;
+  overflow: hidden;
+  background: radial-gradient(circle at 30% 30%, var(--accent), var(--bg));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.profile img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.hero {
+  text-align: center;
+}
+
+.role {
+  margin-top: 0.25rem;
+  color: var(--muted);
+}
+
+.interests {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+  margin: 1rem 0;
+}
+
+.badge {
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  border: 1px solid var(--accent);
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.875rem;
+}
+
+.actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 1.5rem;
+}
+
+.btn {
+  padding: 0.75rem 1.25rem;
+  border-radius: 0.75rem;
+  background: var(--accent);
+  color: var(--bg);
+  border: none;
+  text-decoration: none;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background 0.3s,
+    transform 0.2s;
+}
+
+.btn:hover,
+.btn:focus {
+  background: #0ea5e9;
+  transform: translateY(-2px);
+}
+
+.about,
+.contact {
+  margin-top: 3rem;
+  background: #1e293b;
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+}
+
+.contact ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.contact a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.contact a:hover,
+.contact a:focus {
+  text-decoration: underline;
+}
+
+footer {
+  text-align: center;
+  margin-top: 3rem;
+  color: var(--muted);
+  font-size: 0.875rem;
+}
+
+#toast {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  background: #1e293b;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  opacity: 0;
+  transform: translateY(20px);
+  transition:
+    opacity 0.3s,
+    transform 0.3s;
+  color: var(--fg);
+}
+
+#toast.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.fade-in {
+  opacity: 0;
+  transform: translateY(20px);
+  transition:
+    opacity 0.6s ease-out,
+    transform 0.6s ease-out;
+}
+
+.loaded .fade-in {
+  opacity: 1;
+  transform: translateY(0);
+}


### PR DESCRIPTION
## Summary
- build dark-themed personal portfolio with hero, about, and contact sections
- add styles and animation with CSS and vanilla JS
- include README for local setup and customization

## Testing
- `npx prettier --check index.html style.css script.js README.md`

------
https://chatgpt.com/codex/tasks/task_e_68a4f74f5884832f9244047118fb8ea4